### PR TITLE
Polish org profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,22 +1,73 @@
-## Hi! We are NomaDamas 😆
+<div align="center">
 
-We are AI open-source hacker house backed by [Markr AI](https://github.com/Marker-Inc-Korea), located in Seoul, Korea.
-We are young hackers who loves AI & open source projects.
+# Hi! We are NomaDamas 😆
 
-## Our projects
-- AutoRAG
-- AutoRAG-Research
-- k-skill
-- KoDarkBench : Korean version of DarkBench. See a dark pattern of Korean LLMs. 
-- KICE-slayer : Prompt Engineering project for AI student that can sovle KSAT (Korean-SAT, 수능).
-- awesome-korean-llm : awesome list of Korean LLM models.
-- And many other exciting projects!!!
+**An AI open-source hacker house in Seoul, Korea.**
 
-## Members
-- [Jeffrey Kim](https://github.com/vkehfdl1) : [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG), [KICE-slayer](https://github.com/NomaDamas/KICE_slayer_AI_Korean), [KoDarkBench](https://github.com/NomaDamas/KoDarkBench), and other many projects... Contributor at meta-research and LlamaIndex.
-- [Bobb Kim](https://github.com/bwook00) : [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG), [KICE-slayer](https://github.com/NomaDamas/KICE_slayer_AI_Korean), [KoDarkBench](https://github.com/NomaDamas/KoDarkBench), and other many projects... Contributor at Huggingface and NVIDIA.
-- [Minseong Jin](https://github.com/minsing-jin) : [RAGChain](https://github.com/Marker-Inc-Korea/RAGchain), [KSAT-LLM-Leaderboard](https://github.com/Marker-Inc-Korea/Korean-SAT-LLM-Leaderboard/blob/main/Korean_README.md), and other many projects...
-- [Donggeon Han](https://github.com/Eastsidegunn) : [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG), [RAGChain](https://github.com/Marker-Inc-Korea/RAGchain), [IdolGAN](https://github.com/NomaDamas/IdolGAN), and some other projects...
-- [Doyun Ha](https://github.com/HaD0Yun) : Maintainer of [Oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent?tab=readme-ov-file) and [Oh-my-Codex](https://github.com/Yeachan-Heo/oh-my-codex). Creator of [Gopeak-godot-mcp](https://github.com/HaD0Yun/Gopeak-godot-mcp).
-- [Yongbin Choi](https://github.com/whybe-choi) : Creator of [KoViDoRe](https://github.com/whybe-choi/kovidore-benchmark). Contributor of [mteb](https://github.com/embeddings-benchmark/mteb).
-- [Hyunwook Kwon](https://github.com/Hyunwook-Kwon) : [IdolGAN](https://github.com/NomaDamas/IdolGAN). He is graduate student at Sejong University.
+We are young hackers who love AI & open source. We ship fast, break things, and star-chase. ⭐
+
+[![GitHub Org](https://img.shields.io/badge/GitHub-NomaDamas-181717?logo=github)](https://github.com/NomaDamas)
+[![Backed by Markr](https://img.shields.io/badge/Backed%20by-Markr%20Inc.-orange)](https://github.com/Marker-Inc-Korea)
+
+</div>
+
+---
+
+## 🚀 Our Projects
+
+Our most-loved public repositories (10+ stars), sorted by popularity.
+
+| Project | ⭐ Stars | Description |
+| :--- | :---: | :--- |
+| [k-skill](https://github.com/NomaDamas/k-skill) | 5.7k+ | A skill collection for Koreans — SRT/KTX, KakaoTalk, weather, fine dust, law, stocks, KBO, K-League, LCK, patent search, and much more. |
+| [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG) | 4.8k+ | Open-source framework for RAG evaluation & optimization with AutoML-style automation. _(hosted under Marker-Inc-Korea)_ |
+| [slides-grab](https://github.com/NomaDamas/slides-grab) | 928 | Best harness + editor + linter for generating slides in Claude Code / Codex. An open-source alternative to Claude Design. |
+| [KICE_slayer_AI_Korean](https://github.com/NomaDamas/KICE_slayer_AI_Korean) | 531 | An AI that aims for grade 1 on the Korean SAT (수능) Korean-language exam. |
+| [awesome-korean-llm](https://github.com/NomaDamas/awesome-korean-llm) | 479 | Awesome list of Korean Large Language Models. |
+| [bananatape](https://github.com/NomaDamas/bananatape) | 149 | Vibe design tool for developers — generate, annotate, edit — with your Codex subscription. |
+| [AutoRAG-Research](https://github.com/NomaDamas/AutoRAG-Research) | 141 | Automate your RAG research. |
+| [god-tibo-imagen](https://github.com/NomaDamas/god-tibo-imagen) | 132 | Python & Node package to use the GPT image 2.0 model via Codex subscription. |
+| [KoDarkBench](https://github.com/NomaDamas/KoDarkBench) | 60 | Korean version of DarkBench — spot dark patterns of Korean LLMs. |
+| [girlfriend-in-cli](https://github.com/NomaDamas/girlfriend-in-cli) | 54 | An AI girlfriend/boyfriend that lives in your terminal — real personas, real conversations. |
+| [MinSync](https://github.com/NomaDamas/MinSync) | 49 | Vector DB version control, 100% Rust, cross-platform (Mac, Linux, Windows). |
+| [geobench](https://github.com/NomaDamas/geobench) | 49 | GEO benchmark — open-source alternative to Profound, Semrush, AthenaHQ, etc. |
+| [auto-hongmyungbo](https://github.com/NomaDamas/auto-hongmyungbo) | 34 | Automates promotional posts across multiple social media platforms. |
+| [agentdir](https://github.com/NomaDamas/agentdir) | 34 | `mkdir` for agents — an agent-optimized, read-only virtual folder. |
+| [katok](https://github.com/NomaDamas/katok) | 30 | Give your agent the right to read & search KakaoTalk — BM25 + vector search. |
+| [civStation](https://github.com/NomaDamas/civStation) | 27 | Control Civilization VI with natural voice commands — you strategize, the agent executes. |
+| [KID-F](https://github.com/NomaDamas/KID-F) | 26 | K-pop Idol Dataset (Female) — high-quality face image dataset with identity labels. |
+| [ClueHunter-Perplexity](https://github.com/NomaDamas/ClueHunter-Perplexity) | 24 | Chrome extension that detects the clue of a Perplexity answer on the cited webpage. |
+| [Codexplain](https://github.com/NomaDamas/Codexplain) | 15 | Turns Codex explanations into clear, Claude-like explanations with better UX. |
+| [IdolGAN](https://github.com/NomaDamas/IdolGAN) | 14 | Restoring beautiful K-pop idol images to high quality. |
+| [Saving-Private-Token](https://github.com/NomaDamas/Saving-Private-Token) | 14 | Mad at the 5-minute TTL of Claude Code? Save your private token — the KV cache reset is sin. |
+| [hwp-converter-api](https://github.com/NomaDamas/hwp-converter-api) | 13 | API server that converts HWP files — thanks to hwplib & hwpxlib. |
+| [dani](https://github.com/NomaDamas/dani) | 13 | Automate the GitHub Issue/PR process. |
+| [ClueHunter.js](https://github.com/NomaDamas/ClueHunter.js) | 11 | Find the exact evidence paragraph from a web page with a fully-local model. |
+
+> And many other exciting projects! Check out [all of our repositories](https://github.com/orgs/NomaDamas/repositories). 🔥
+
+---
+
+## 👥 Members
+
+- **[Jeffrey Kim](https://github.com/vkehfdl1)** — Lead contributor of [k-skill](https://github.com/NomaDamas/k-skill), [slides-grab](https://github.com/NomaDamas/slides-grab), [KICE-slayer](https://github.com/NomaDamas/KICE_slayer_AI_Korean), [awesome-korean-llm](https://github.com/NomaDamas/awesome-korean-llm), [AutoRAG-Research](https://github.com/NomaDamas/AutoRAG-Research), [MinSync](https://github.com/NomaDamas/MinSync), [geobench](https://github.com/NomaDamas/geobench), and more. Contributor at meta-research and LlamaIndex.
+- **[Bobb Kim](https://github.com/bwook00)** — Lead contributor of [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG) and [KoDarkBench](https://github.com/NomaDamas/KoDarkBench). Core contributor of [KICE-slayer](https://github.com/NomaDamas/KICE_slayer_AI_Korean). Contributor at Huggingface and NVIDIA.
+- **[Minseong Jin](https://github.com/minsing-jin)** — Lead contributor of [girlfriend-in-cli](https://github.com/NomaDamas/girlfriend-in-cli), [auto-hongmyungbo](https://github.com/NomaDamas/auto-hongmyungbo), [civStation](https://github.com/NomaDamas/civStation), and [Codexplain](https://github.com/NomaDamas/Codexplain). Also worked on [RAGChain](https://github.com/Marker-Inc-Korea/RAGchain).
+- **[Donggeon Han](https://github.com/Eastsidegunn)** — Core contributor of [AutoRAG](https://github.com/Marker-Inc-Korea/AutoRAG), [RAGChain](https://github.com/Marker-Inc-Korea/RAGchain), and [IdolGAN](https://github.com/NomaDamas/IdolGAN).
+- **[Doyun Ha](https://github.com/HaD0Yun)** — Core contributor of [bananatape](https://github.com/NomaDamas/bananatape). Maintainer of [Oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent) and [Oh-my-Codex](https://github.com/Yeachan-Heo/oh-my-codex). Creator of [Gopeak-godot-mcp](https://github.com/HaD0Yun/Gopeak-godot-mcp).
+- **[Yongbin Choi](https://github.com/whybe-choi)** — Core contributor of [AutoRAG-Research](https://github.com/NomaDamas/AutoRAG-Research). Creator of [KoViDoRe](https://github.com/whybe-choi/kovidore-benchmark). Contributor of [mteb](https://github.com/embeddings-benchmark/mteb).
+- **[Hyunwook Kwon](https://github.com/Hyunwook-Kwon)** — Core contributor of [slides-grab](https://github.com/NomaDamas/slides-grab) and [KID-F](https://github.com/NomaDamas/KID-F). Contributor of [IdolGAN](https://github.com/NomaDamas/IdolGAN). Graduate student at Sejong University.
+
+---
+
+## 💛 Backed by Markr Inc.
+
+NomaDamas is proudly backed by **[Markr Inc.](https://github.com/Marker-Inc-Korea)**
+
+### Token Sponsors
+
+A huge thank-you to our token sponsors who keep our agents running:
+
+- [@code-yeongyu](https://github.com/code-yeongyu)
+- [@Yeachan-Heo](https://github.com/Yeachan-Heo)
+- [@berkshirehathaways](https://github.com/berkshirehathaways)


### PR DESCRIPTION
Refreshes the NomaDamas org profile.

## Changes
- Rewrote the profile in English with a cleaner, centered header.
- Added a **ranked project table** of public repos with 10+ stars (sorted by stars). Includes AutoRAG (hosted under Marker-Inc-Korea).
- Updated **Members** so each person's history includes the projects they are the #1 contributor on.
- Added a **Backed by Markr Inc.** section.
- Added **Token Sponsors**: @code-yeongyu, @Yeachan-Heo, @berkshirehathaways.

Star counts pulled from the GitHub API at authoring time.